### PR TITLE
Update notify.py

### DIFF
--- a/custom_components/mysql_command/notify.py
+++ b/custom_components/mysql_command/notify.py
@@ -66,6 +66,7 @@ class MySQLCommandNotificationService(BaseNotificationService):
             username=self.username,
             password=self.password,
             db=self.db,
+            connection_timeout=10,
         )
         cursor = cnx.cursor(buffered=True)  # (buffered=True)
         cursor.execute(message)


### PR DESCRIPTION
Introduced connection_timeout value (10 seconds) to mysql.connector.connect (See Issue #2) Note / Idea: Maybe put timeout value into optional configuration parameter.